### PR TITLE
Changed BUSY_WAIT to 2000ms

### DIFF
--- a/src/LOLIN_IL3897.cpp
+++ b/src/LOLIN_IL3897.cpp
@@ -1,8 +1,6 @@
 #include "LOLIN_EPD.h"
 #include "LOLIN_IL3897.h"
 
-#define ALLSCREEN_GRAGHBYTES 4000
-
 ///////////////////////////////////////////////////
 
 
@@ -169,8 +167,6 @@ const unsigned char LUT_DATA_part[] PROGMEM = {
     0x30,
     0x0A,
 };
-
-#define BUSY_WAIT 1000
 
 /*!
     @brief constructor if using on-chip RAM and software SPI

--- a/src/LOLIN_IL3897.h
+++ b/src/LOLIN_IL3897.h
@@ -1,6 +1,9 @@
 #ifndef __LOLIN_IL3897_H
 #define __LOLIN_IL3897_H
 
+#define ALLSCREEN_GRAGHBYTES 4000
+#define BUSY_WAIT 2000
+
 #ifdef __AVR__
   #include <avr/pgmspace.h>
 #elif defined(ESP8266) || defined(ESP32)
@@ -24,12 +27,12 @@ class LOLIN_IL3897 : public LOLIN_EPD {
 	  LOLIN_IL3897(int width, int height, int8_t DC, int8_t RST, int8_t CS, int8_t BUSY = -1);
 
 	void begin(bool reset=true);
-	
+
 	void drawPixel(int16_t x, int16_t y, uint16_t color);
-	
+
 	void display();
 	void update();
-	
+
 	void clearBuffer();
 	void clearDisplay();
 


### PR DESCRIPTION
I'm assuming the library is used for https://wiki.wemos.cc/products:d1_mini_shields:epd_2.13_shield which is what I'm testing my code on with the wemos d1 mini v3.1.0

Moved #define from .cpp to .h for better readability

Changed BUSY_WAIT from 1000 to 2000 as per waveshare 2.13 full refresh 
time of 2s found on 
https://www.waveshare.com/product/2.13inch-e-paper-hat.htm (tested and 
found to fix the graphics test endPrintTest not displaying)

Fixes #5 