### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -13,14 +13,14 @@ LOLIN_IL3897	KEYWORD1
 #######################################
 
 clearBuffer	KEYWORD2
-drawPixel   KEYWORD2
+drawPixel	KEYWORD2
 
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-EPD_BLACK   LITERAL1
+EPD_BLACK	LITERAL1
 EPD_WHITE	LITERAL1
 EPD_INVERSE	LITERAL1
 EPD_RED	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords